### PR TITLE
Add resource (dataset)  to Proto::Trace::V1::ResourceSpans

### DIFF
--- a/src/api.cr
+++ b/src/api.cr
@@ -11,6 +11,7 @@ module OpenTelemetry
 
       def to_protobuf
         Proto::Trace::V1::ResourceSpans.new(
+          resource: resource_from_env,
           instrumentation_library_spans: [
             Proto::Trace::V1::InstrumentationLibrarySpans.new(
               instrumentation_library: Proto::Common::V1::InstrumentationLibrary.new(
@@ -20,6 +21,19 @@ module OpenTelemetry
               spans: spans.map(&.to_protobuf)
             ),
           ],
+        )
+      end
+
+      def resource_from_env
+        return nil if ENV["HONEYCOMB_DATASET"]?.nil?
+
+        Proto::Resource::V1::Resource.new(
+          attributes: [
+            OpenTelemetry::Proto::Common::V1::KeyValue.new(
+              key: "service.name",
+              value: OpenTelemetry::Proto::Common::V1::AnyValue.new(ENV["HONEYCOMB_DATASET"])
+            )
+          ]
         )
       end
     end

--- a/src/api.cr
+++ b/src/api.cr
@@ -29,9 +29,9 @@ module OpenTelemetry
 
         Proto::Resource::V1::Resource.new(
           attributes: [
-            OpenTelemetry::Proto::Common::V1::KeyValue.new(
+            Proto::Common::V1::KeyValue.new(
               key: "service.name",
-              value: OpenTelemetry::Proto::Common::V1::AnyValue.new(ENV["HONEYCOMB_DATASET"])
+              value: Proto::Common::V1::AnyValue.new(ENV["HONEYCOMB_DATASET"])
             )
           ]
         )

--- a/src/api.cr
+++ b/src/api.cr
@@ -8,10 +8,11 @@ module OpenTelemetry
     class Trace
       getter id : Bytes = Random::Secure.random_bytes(16)
       getter spans = [] of Span
+      property resource : Proto::Resource::V1::Resource? = nil
 
       def to_protobuf
         Proto::Trace::V1::ResourceSpans.new(
-          resource: resource_from_env,
+          resource: resource,
           instrumentation_library_spans: [
             Proto::Trace::V1::InstrumentationLibrarySpans.new(
               instrumentation_library: Proto::Common::V1::InstrumentationLibrary.new(
@@ -21,19 +22,6 @@ module OpenTelemetry
               spans: spans.map(&.to_protobuf)
             ),
           ],
-        )
-      end
-
-      def resource_from_env
-        return nil if ENV["HONEYCOMB_DATASET"]?.nil?
-
-        Proto::Resource::V1::Resource.new(
-          attributes: [
-            Proto::Common::V1::KeyValue.new(
-              key: "service.name",
-              value: Proto::Common::V1::AnyValue.new(ENV["HONEYCOMB_DATASET"])
-            )
-          ]
         )
       end
     end

--- a/src/opentelemetry.cr
+++ b/src/opentelemetry.cr
@@ -132,7 +132,7 @@ module OpenTelemetry
     end
 
     if env_resource_attributes = ENV["OTEL_RESOURCE_ATTRIBUTES"]?
-      env_resource_attributes.split(',').compact_map do |attribute|
+      env_resource_attributes.split(',').each do |attribute|
         key_value_attr = attribute.split('=')
         key = key_value_attr.first
         value = key_value_attr.last

--- a/src/opentelemetry.cr
+++ b/src/opentelemetry.cr
@@ -28,6 +28,7 @@ module OpenTelemetry
   # ```
   def self.trace(name : String)
     trace = current_trace
+    trace.resource = CONFIG.resource
     is_new_trace = current_trace_id.nil?
     trace_id = self.current_trace_id ||= Random::Secure.random_bytes(16)
     previous_current_span = current_span
@@ -94,10 +95,14 @@ module OpenTelemetry
   end
 
   # Global OpenTelemetry configuration, intended to be called when your
-  # application starts. See `OpenTelemetry::Configuration` for more details.
+  # application starts. Supports loading configs from `OTEL_SERVICE_NAME` and
+  # `OTEL_RESOURCE_ATTRIBUTES` environment variables but it won't override what
+  # was previously configured in the block. See `OpenTelemetry::Configuration`
+  # for more details.
   #
   # ```
   # OpenTelemetry.configure do |c|
+  #   c.service_name = "crystal-service"
   #   c.exporter = OpenTelemetry::HTTPExporter.new(
   #     # Send data to Honeycomb
   #     endpoint: URI.parse("https://api.honeycomb.io")
@@ -110,6 +115,47 @@ module OpenTelemetry
   # ```
   def self.configure
     yield CONFIG
+
+    if ENV["OTEL_SERVICE_NAME"]?.presence && !CONFIG.service_name.presence
+      CONFIG.service_name = ENV["OTEL_SERVICE_NAME"]
+    end
+
+    # No need to configure the resource if already assigned within yield block
+    return unless CONFIG.resource.nil?
+
+    resource_attributes = [] of Proto::Common::V1::KeyValue
+    if CONFIG.service_name.presence
+      resource_attributes << Proto::Common::V1::KeyValue.new(
+        key: "service.name",
+        value: Proto::Common::V1::AnyValue.new(CONFIG.service_name)
+      )
+    end
+
+    if env_resource_attributes = ENV["OTEL_RESOURCE_ATTRIBUTES"]?
+      env_resource_attributes.split(',').compact_map do |attribute|
+        key_value_attr = attribute.split('=')
+        key = key_value_attr.first
+        value = key_value_attr.last
+
+        # Skip if service name was already defined (previous takes precedence)
+        next if key == "service.name" && CONFIG.service_name.presence
+
+        # Ensure service name is loaded to CONFIG if assigned here
+        CONFIG.service_name = value if key == "service.name"
+
+        resource_attributes << Proto::Common::V1::KeyValue.new(
+          key: key,
+          value: Proto::Common::V1::AnyValue.new(value)
+        )
+      end
+    end
+
+    # Create shared resource if service name was assigned
+    if CONFIG.service_name.presence
+      CONFIG.resource = Proto::Resource::V1::Resource.new(
+        attributes: resource_attributes
+      )
+    end
   end
 
   # Configuration for OpenTelemetry, see `OpenTelemetry.configure` for usage.
@@ -117,6 +163,7 @@ module OpenTelemetry
     # Set the `OpenTelemetry::Exporter` instance.
     property exporter : Exporter = NullExporter.new
     property service_name : String? = ""
+    property resource : Proto::Resource::V1::Resource? = nil
   end
 
   # :nodoc:

--- a/src/opentelemetry.cr
+++ b/src/opentelemetry.cr
@@ -114,11 +114,9 @@ module OpenTelemetry
   # end
   # ```
   def self.configure
-    yield CONFIG
+    CONFIG.service_name = ENV["OTEL_SERVICE_NAME"]?
 
-    if ENV["OTEL_SERVICE_NAME"]?.presence && !CONFIG.service_name.presence
-      CONFIG.service_name = ENV["OTEL_SERVICE_NAME"]
-    end
+    yield CONFIG
 
     # No need to configure the resource if already assigned within yield block
     return unless CONFIG.resource.nil?
@@ -133,9 +131,7 @@ module OpenTelemetry
 
     if env_resource_attributes = ENV["OTEL_RESOURCE_ATTRIBUTES"]?
       env_resource_attributes.split(',').each do |attribute|
-        key_value_attr = attribute.split('=')
-        key = key_value_attr.first
-        value = key_value_attr.last
+        key, value = attribute.split('=')
 
         # Skip if service name was already defined (previous takes precedence)
         next if key == "service.name" && CONFIG.service_name.presence


### PR DESCRIPTION
Hey Jamie! Hope you're doing well 👋🏼 😄 

I used your shard to upload traces to Honeycomb but I ran into a problem. Datasets weren't assigned properly on Honeycomb's dashboard and it seems to be because the `x-honeycomb-dataset` HTTP header only works on [Honeycomb classic](https://docs.honeycomb.io/honeycomb-classic/) accounts.

This PR adds a resource to the Trace, which is how they seem to be expecting the `service.name` to appear (not as an attribute). I tested it and now datasets are being identified/assigned on my dashboard.

Let me know if this fix looks okay or if I need to update it in a different way.